### PR TITLE
Docker 101: doc fixes encountered in live class

### DIFF
--- a/docker_101.md
+++ b/docker_101.md
@@ -1,6 +1,6 @@
 # Use Docker Container to start and stop groups of hosts
 
-`docker-compose up`
+`docker-compose up -d`
 
 `docker-compose down`
 
@@ -16,7 +16,7 @@ Configuration is in `docker-compose.yml`.
 `docker port alpha`
 
 ## Get a shell on a running container
-`docker-exec -it alpha /bin/bash`
+`docker exec -it alpha /bin/bash`
 
 ## Get rid of containers
 ### Kill a running container


### PR DESCRIPTION
- `docker exec` not `docker-exec`
- Detached mode `docker-compose up -d` is clean way to background, without container stdout interrupting foreground shell interactivity.